### PR TITLE
allow using custome configuration directory for psalm

### DIFF
--- a/bin/roave-infection-static-analysis-plugin
+++ b/bin/roave-infection-static-analysis-plugin
@@ -23,6 +23,7 @@ use function defined;
 use function getcwd;
 use function sprintf;
 use function var_export;
+use function getenv;
 
 (static function (): void {
     $projectPath = (static function () : string {
@@ -59,7 +60,10 @@ use function var_export;
     $makeAnalyzer = static function () use ($projectPath): ProjectAnalyzer {
         RuntimeCaches::clearAll();
 
-        $config = Config::getConfigForPath($projectPath, $projectPath);
+        $configDirectory = getenv('PROJECT_CONFIG_DIRECTORY') ?: '';
+        $configPath = '' !== $configDirectory ? ($projectPath . '/' . $configDirectory) : $projectPath;
+
+        $config = Config::getConfigForPath($configPath, $projectPath);
 
         $config->setIncludeCollector(new IncludeCollector());
 


### PR DESCRIPTION
I was trying to use this project with PSL, and it didn't work well, since PSL stores all configuration files in `config/` directory.

using this patch, I'm able to keep the same structure, by setting `PROJECT_CONFIG_DIRECTORY` env variable to `config`.