### PR TITLE
fix(bootstrap): use same container instance to create mutation execution result factory

### DIFF
--- a/src/Roave/InfectionStaticAnalysis/Bootstrapper.php
+++ b/src/Roave/InfectionStaticAnalysis/Bootstrapper.php
@@ -18,17 +18,16 @@ final class Bootstrapper
     ): Container {
         $reflectionOffsetSet = (new ReflectionMethod(Container::class, 'offsetSet'));
 
-        $new_container = clone $container;
-        $factory       = static function () use ($container, $runStaticAnalysis): MutantExecutionResultFactory {
+        $factory = static function (Container $container) use ($runStaticAnalysis): MutantExecutionResultFactory {
             return new RunStaticAnalysisAgainstEscapedMutant(
-                $container->getMutantExecutionResultFactory(),
+                new MutantExecutionResultFactory($container->getTestFrameworkAdapter()),
                 $runStaticAnalysis,
             );
         };
 
         $reflectionOffsetSet->setAccessible(true);
-        $reflectionOffsetSet->invokeArgs($new_container, [MutantExecutionResultFactory::class, $factory]);
+        $reflectionOffsetSet->invokeArgs($container, [MutantExecutionResultFactory::class, $factory]);
 
-        return $new_container;
+        return $container;
     }
 }


### PR DESCRIPTION
So this is a bit more complicated than i initially expected.

once infection reads arguments/options/flags, it reconstructs a new container instance with a modified configuration instance, since our old container `$container` will not get access to this new configuration instance, it will use the old one when creating the mutation execution result factory, making it so that some part of infection use the default config ( mutation execution result factory being one of them ), while everything else uses the correct configuration instance that was injected in the command after reading the configuration from CLI input.

In this PR, i modified the factory so that we don't create a clone, instead, we construct a new instance of mutation execution result factory by reading everything it needs from the container.

I have tested this locally, and it works perfectly.

( this should be considered a bug and released as 1.11.1 )