### PR TITLE
Fixed resolving project directory

### DIFF
--- a/bin/roave-infection-static-analysis-plugin
+++ b/bin/roave-infection-static-analysis-plugin
@@ -30,9 +30,9 @@ use function var_export;
 (static function (): void {
     $projectPath = (static function () : string {
         $projectDirectoryCandidates = [
-            'current-working-directory'        => getcwd(),
-            'installed-as-composer-dependency' => __DIR__ . '/../../..',
+            'installed-as-composer-dependency' => __DIR__ . '/../../../..',
             'installed-as-project'             => __DIR__ . '/..',
+            'current-working-directory'        => getcwd(),
         ];
 
         foreach ($projectDirectoryCandidates as $candidatePath) {


### PR DESCRIPTION
It should help with https://github.com/Roave/BetterReflection/pull/1391

- `installed-as-composer-dependency` is missing one `..`
- I've changed the resolving order because we need to resolve `installed-as-composer-dependency` before `current-working-directory`